### PR TITLE
Update to .NET 8 , EF 8

### DIFF
--- a/Innofactor.EfCoreJsonValueConverter.Test/Innofactor.EfCoreJsonValueConverter.Test.csproj
+++ b/Innofactor.EfCoreJsonValueConverter.Test/Innofactor.EfCoreJsonValueConverter.Test.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />

--- a/Innofactor.EfCoreJsonValueConverter/Innofactor.EfCoreJsonValueConverter.csproj
+++ b/Innofactor.EfCoreJsonValueConverter/Innofactor.EfCoreJsonValueConverter.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Innofactor</Authors>
     <Company>Innofactor</Company>
-    <Description>JSON value converter for Entity Framework Core 6.0+</Description>
+    <Description>JSON value converter for Entity Framework Core 8.0+</Description>
     <PackageLicenseUrl>https://github.com/Innofactor/EfCoreJsonValueConverter/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Innofactor/EfCoreJsonValueConverter</PackageProjectUrl>
     <PackageIconUrl>http://rappen.net/Cinteros/innofactor.png</PackageIconUrl>
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Innofactor.EfCoreJsonValueConverter.Attributes" Version="2.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# JSON value converter for Entity Framework Core 3.0+
+﻿# JSON value converter for Entity Framework Core 8.0+
 
 ![Publish NuGet](https://github.com/Innofactor/EfCoreJsonValueConverter/workflows/Publish%20NuGet/badge.svg)
 


### PR DESCRIPTION
.NET 6 is out of support, so I figured I'd update dependencies to next LTS, which is .NET 8.

Ran tests, and everything seems fine.

This library is still useful, even with the built-in support for JSON fields in EF, because the way this library does it is a lot simpler.